### PR TITLE
fix: Correct workflow condition for plan label detection

### DIFF
--- a/.github/workflows/plan-to-issues.yml
+++ b/.github/workflows/plan-to-issues.yml
@@ -12,7 +12,10 @@ concurrency:
 jobs:
   create-subtasks:
     # Only run if issue has 'plan' label
-    if: contains(github.event.issue.labels.*.name, 'plan')
+    # Check if the plan label was just added, or if issue was opened with plan label
+    if: |
+      github.event.action == 'labeled' && github.event.label.name == 'plan' ||
+      github.event.action == 'opened' && contains(toJSON(github.event.issue.labels.*.name), 'plan')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

The plan-to-issues workflow was never triggering because the if condition was incorrectly checking for the plan label. The condition was always evaluating to false, causing the workflow to skip.

## Solution

Fixed the condition to properly check both trigger scenarios:
- When labeled action occurs, check if label.name == plan
- When opened action occurs, check if plan exists in labels array

This ensures the workflow triggers when:
1. Label added: A user adds the plan label to an existing issue
2. Issue opened: A new issue is created with the plan label already applied

## Testing

After merge, will test with issue 23 by removing and re-adding the plan label to verify:
- Workflow triggers correctly
- Claude parses tasks
- Child issues created
- Everything linked and added to project board

## References

- Original implementation: PR 22
- Test issue: 23
- Documentation: .github/PLAN_TO_ISSUES.md