### PR TITLE
fix(docs): add /sync-todos-to-github to README table and correct command count

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cp -r generated-skills/prompt-factory ~/.claude/skills/
 
 ## 📋 Built-in Commands
 
-This toolkit includes **11 slash commands** and **5 interactive agents** to streamline your workflow:
+This toolkit includes **10 slash commands** and **5 interactive agents** to streamline your workflow:
 
 ### Workflow Commands
 
@@ -46,6 +46,7 @@ This toolkit includes **11 slash commands** and **5 interactive agents** to stre
 | `/factory-status` | Check system status (all factories) | `/factory-status` |
 | `/sync-agents-md` | Generate AGENTS.md from CLAUDE.md | `/sync-agents-md` |
 | `/codex-exec` | Execute Codex CLI commands | `/codex-exec analysis "task"` |
+| `/sync-todos-to-github` | Convert TodoWrite tasks to GitHub issues | `/sync-todos-to-github "Sprint 12"` |
 
 ### Interactive Guide Agents
 


### PR DESCRIPTION
## Summary
Fix inconsistency in README.md introduced in PR #1003 where the command count was updated but the command was not added to the table.

## Context
**PR #1003** added the `/sync-todos-to-github` command and updated the count from 10 to 11, but forgot to add the command to the Workflow Commands table in README.md. This created a mismatch between the stated count and the visible commands.

## Changes

### README.md
**Before**:
- States "11 slash commands"
- Table shows only 9 commands
- `/sync-todos-to-github` missing from table

**After**:
- States "10 slash commands" (correct count)
- Table shows 10 commands
- `/sync-todos-to-github` included with description and example

**Change**:
```diff
-This toolkit includes **11 slash commands** and **5 interactive agents**
+This toolkit includes **10 slash commands** and **5 interactive agents**

 | `/codex-exec` | Execute Codex CLI commands | `/codex-exec analysis "task"` |
+| `/sync-todos-to-github` | Convert TodoWrite tasks to GitHub issues | `/sync-todos-to-github "Sprint 12"` |
```

## Testing

- [x] **Count verification**: 10 commands listed in table matches "10 slash commands" text
- [x] **Command listing**: All 10 commands now visible in README
- [x] **Example syntax**: Follows same format as other commands

**Commands in table**:
1. /build
2. /build-hook
3. /validate-output
4. /install-skill
5. /install-hook
6. /test-factory
7. /factory-status
8. /sync-agents-md
9. /codex-exec
10. /sync-todos-to-github ✨ (now visible)

## Security

- [x] No security implications (documentation-only change)
- [x] No code changes

## Documentation

- [x] README.md updated (this PR)
- [x] .claude/commands/README.md already correct (from PR #1003)
- [x] Command documentation exists (.claude/commands/sync-todos-to-github.md from PR #1003)

## Reviewers

- [ ] @alirezarezvani

## Related Issues

Fixes inconsistency introduced in PR #1003

---

**Type**: fix  
**Scope**: docs

---

## Impact

**Before**: Users see "11 slash commands" but only 9 in the table → confusion  
**After**: Users see "10 slash commands" and all 10 in the table → clear

This is a documentation-only fix with no functional changes.